### PR TITLE
Add object independent bounds

### DIFF
--- a/staticmaps/__init__.py
+++ b/staticmaps/__init__.py
@@ -21,7 +21,7 @@ from .color import (
     TRANSPARENT,
 )
 from .context import Context
-from .coordinates import create_latlng, parse_latlng, parse_latlngs
+from .coordinates import create_latlng, parse_latlng, parse_latlngs, parse_latlngs2rect
 from .image_marker import ImageMarker
 from .line import Line
 from .marker import Marker

--- a/staticmaps/cli.py
+++ b/staticmaps/cli.py
@@ -122,7 +122,7 @@ def main() -> None:
         for coords in args.marker:
             context.add_object(staticmaps.Marker(staticmaps.parse_latlng(coords)))
     if args.bounds is not None:
-        context.set_bounds(staticmaps.parse_latlngs2rect(args.bounds))
+        context.add_bounds(staticmaps.parse_latlngs2rect(args.bounds))
 
     file_name = args.filename[0]
     if determine_file_format(args.file_format, file_name) == FileFormat.PNG:

--- a/staticmaps/cli.py
+++ b/staticmaps/cli.py
@@ -75,6 +75,11 @@ def main() -> None:
         action="append",
     )
     args_parser.add_argument(
+        "--bounds",
+        metavar="LAT,LNG LAT,LNG",
+        type=str,
+    )
+    args_parser.add_argument(
         "--tiles",
         metavar="TILEPROVIDER",
         type=str,
@@ -116,6 +121,8 @@ def main() -> None:
     if args.marker:
         for coords in args.marker:
             context.add_object(staticmaps.Marker(staticmaps.parse_latlng(coords)))
+    if args.bounds is not None:
+        context.set_bounds(staticmaps.parse_latlngs2rect(args.bounds))
 
     file_name = args.filename[0]
     if determine_file_format(args.file_format, file_name) == FileFormat.PNG:

--- a/staticmaps/context.py
+++ b/staticmaps/context.py
@@ -40,9 +40,6 @@ class Context:
     def set_center(self, latlng: s2sphere.LatLng) -> None:
         self._center = latlng
 
-    def set_bounds(self, latlngrect: s2sphere.LatLngRect) -> None:
-        self._bounds = latlngrect
-
     def set_background_color(self, color: Color) -> None:
         self._background_color = color
 
@@ -57,6 +54,9 @@ class Context:
 
     def add_object(self, obj: Object) -> None:
         self._objects.append(obj)
+
+    def add_bounds(self, latlngrect: s2sphere.LatLngRect) -> None:
+        self._bounds = latlngrect
 
     def render_cairo(self, width: int, height: int) -> typing.Any:
         if not cairo_is_supported():
@@ -112,9 +112,9 @@ class Context:
             bounds = s2sphere.LatLngRect()
             for obj in self._objects:
                 bounds = bounds.union(obj.bounds())
-        return self.custom_bounds(bounds)
+        return self._custom_bounds(bounds)
 
-    def custom_bounds(self, bounds: s2sphere.LatLngRect) -> typing.Optional[s2sphere.LatLngRect]:
+    def _custom_bounds(self, bounds: s2sphere.LatLngRect) -> typing.Optional[s2sphere.LatLngRect]:
         """check for custom bounds and return the union with object bounds
 
         :param bounds: boundaries from objects

--- a/staticmaps/context.py
+++ b/staticmaps/context.py
@@ -26,6 +26,7 @@ class Context:
         self._background_color: typing.Optional[Color] = None
         self._objects: typing.List[Object] = []
         self._center: typing.Optional[s2sphere.LatLng] = None
+        self._bounds: typing.Optional[s2sphere.LatLngRect] = None
         self._zoom: typing.Optional[int] = None
         self._tile_provider = tile_provider_OSM
         self._tile_downloader = TileDownloader()
@@ -38,6 +39,9 @@ class Context:
 
     def set_center(self, latlng: s2sphere.LatLng) -> None:
         self._center = latlng
+
+    def set_bounds(self, latlngrect: s2sphere.LatLngRect) -> None:
+        self._bounds = latlngrect
 
     def set_background_color(self, color: Color) -> None:
         self._background_color = color
@@ -103,12 +107,26 @@ class Context:
         return renderer.drawing()
 
     def object_bounds(self) -> typing.Optional[s2sphere.LatLngRect]:
-        if len(self._objects) == 0:
-            return None
-        bounds = s2sphere.LatLngRect()
-        for obj in self._objects:
-            bounds = bounds.union(obj.bounds())
-        return bounds
+        bounds = None
+        if len(self._objects) != 0:
+            bounds = s2sphere.LatLngRect()
+            for obj in self._objects:
+                bounds = bounds.union(obj.bounds())
+        return self.custom_bounds(bounds)
+
+    def custom_bounds(self, bounds: s2sphere.LatLngRect) -> typing.Optional[s2sphere.LatLngRect]:
+        """check for custom bounds and return the union with object bounds
+
+        :param bounds: boundaries from objects
+        :type bounds: s2sphere.LatLngRect
+        :return: return the union with object bounds
+        :rtype s2sphere.LatLngRect
+        """
+        if not self._bounds:
+            return bounds
+        if not bounds:
+            return self._bounds
+        return bounds.union(self._bounds)
 
     def extra_pixel_bounds(self) -> PixelBoundsT:
         max_l, max_t, max_r, max_b = 0, 0, 0, 0

--- a/staticmaps/context.py
+++ b/staticmaps/context.py
@@ -22,6 +22,7 @@ from .transformer import Transformer
 
 
 class Context:
+    # pylint: disable=too-many-instance-attributes
     def __init__(self) -> None:
         self._background_color: typing.Optional[Color] = None
         self._objects: typing.List[Object] = []

--- a/staticmaps/coordinates.py
+++ b/staticmaps/coordinates.py
@@ -34,3 +34,18 @@ def parse_latlngs(s: str) -> typing.List[s2sphere.LatLng]:
         if len(c) > 0:
             res.append(parse_latlng(c))
     return res
+
+
+def parse_latlngs2rect(s: str) -> s2sphere.LatLngRect:
+    """Return a LatLngRect from a given Lat,Lng pair
+
+    :param s: string with given comma separated Lat,Lng pairs
+    :type s: str
+    :return: LatLngRect from LatLng pair
+    .:rtype: s2sphere.LatLngRect
+    """
+    latlngs = parse_latlngs(s)
+    if not len(latlngs) == 2:
+        raise ValueError(f'Cannot parse coordinates string "{s}" (requires exactly two lat/lng pairs)')
+
+    return s2sphere.LatLngRect.from_point_pair(latlngs[0], latlngs[1])

--- a/staticmaps/coordinates.py
+++ b/staticmaps/coordinates.py
@@ -39,13 +39,14 @@ def parse_latlngs(s: str) -> typing.List[s2sphere.LatLng]:
 def parse_latlngs2rect(s: str) -> s2sphere.LatLngRect:
     """Return a LatLngRect from a given Lat,Lng pair
 
-    :param s: string with given comma separated Lat,Lng pairs
+    :param s: string with given exactly two comma separated Lat,Lng pairs
     :type s: str
     :return: LatLngRect from LatLng pair
-    .:rtype: s2sphere.LatLngRect
+    :rtype: s2sphere.LatLngRect
+    :raises ValueError: exactly two lat/lng pairs must be given as argument
     """
     latlngs = parse_latlngs(s)
-    if not len(latlngs) == 2:
+    if len(latlngs) != 2:
         raise ValueError(f'Cannot parse coordinates string "{s}" (requires exactly two lat/lng pairs)')
 
     return s2sphere.LatLngRect.from_point_pair(latlngs[0], latlngs[1])

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -30,6 +30,18 @@ def test_bounds() -> None:
         staticmaps.create_latlng(47, 7), staticmaps.create_latlng(48, 8)
     )
 
+    context.add_bounds(s2sphere.LatLngRect(staticmaps.create_latlng(46, 6), staticmaps.create_latlng(49, 9)))
+    assert context.object_bounds() is not None
+    assert context.object_bounds() == s2sphere.LatLngRect(
+        staticmaps.create_latlng(46, 6), staticmaps.create_latlng(49, 9)
+    )
+
+    context.add_bounds(s2sphere.LatLngRect(staticmaps.create_latlng(47.5, 7.5), staticmaps.create_latlng(48, 8)))
+    assert context.object_bounds() is not None
+    assert context.object_bounds() == s2sphere.LatLngRect(
+        staticmaps.create_latlng(47, 7), staticmaps.create_latlng(48, 8)
+    )
+
 
 def test_render_empty() -> None:
     context = staticmaps.Context()

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -40,3 +40,15 @@ def test_parse_latlngs() -> None:
     for s in bad:
         with pytest.raises(ValueError):
             staticmaps.parse_latlngs(s)
+
+
+def test_parse_latlngs2rect() -> None:
+    good = ["48,8 47,7", "   48,8    47,7   "]
+    for s in good:
+        r = staticmaps.parse_latlngs2rect(s)
+        assert r.is_valid()
+
+    bad = ["xyz", "48,8 xyz", "48,8 48,181", "48,7", "48,7 48,8 47,7"]
+    for s in bad:
+        with pytest.raises(ValueError):
+            staticmaps.parse_latlngs2rect(s)


### PR DESCRIPTION
This PR adds an option to add bounds to be respected in zoom calculation without having to add objects.