### PR TITLE
Add extra pixel bounds to add_bounds() method

### DIFF
--- a/staticmaps/context.py
+++ b/staticmaps/context.py
@@ -106,8 +106,6 @@ class Context:
         :type extra_pixel_bounds: int, tuple
         """
         self._bounds = latlngrect
-        print(self._extra_pixel_bounds)
-        print(extra_pixel_bounds)
         if extra_pixel_bounds:
             if isinstance(extra_pixel_bounds, tuple):
                 self._extra_pixel_bounds = extra_pixel_bounds
@@ -118,7 +116,6 @@ class Context:
                     extra_pixel_bounds,
                     extra_pixel_bounds,
                 )
-        print(self._extra_pixel_bounds)
 
     def render_cairo(self, width: int, height: int) -> typing.Any:
         """Render area using cairo

--- a/staticmaps/context.py
+++ b/staticmaps/context.py
@@ -28,6 +28,7 @@ class Context:
         self._objects: typing.List[Object] = []
         self._center: typing.Optional[s2sphere.LatLng] = None
         self._bounds: typing.Optional[s2sphere.LatLngRect] = None
+        self._extra_pixel_bounds: typing.Tuple[int, int, int, int] = (0, 0, 0, 0)
         self._zoom: typing.Optional[int] = None
         self._tile_provider = tile_provider_OSM
         self._tile_downloader = TileDownloader()
@@ -92,13 +93,32 @@ class Context:
         """
         self._objects.append(obj)
 
-    def add_bounds(self, latlngrect: s2sphere.LatLngRect) -> None:
+    def add_bounds(
+        self,
+        latlngrect: s2sphere.LatLngRect,
+        extra_pixel_bounds: typing.Optional[typing.Union[int, typing.Tuple[int, int, int, int]]] = None,
+    ) -> None:
         """Add boundaries that shall be respected by the static map
 
         :param latlngrect: boundaries to be respected
         :type latlngrect: s2sphere.LatLngRect
+        :param extra_pixel_bounds: extra pixel bounds to be respected
+        :type extra_pixel_bounds: int, tuple
         """
         self._bounds = latlngrect
+        print(self._extra_pixel_bounds)
+        print(extra_pixel_bounds)
+        if extra_pixel_bounds:
+            if isinstance(extra_pixel_bounds, tuple):
+                self._extra_pixel_bounds = extra_pixel_bounds
+            else:
+                self._extra_pixel_bounds = (
+                    extra_pixel_bounds,
+                    extra_pixel_bounds,
+                    extra_pixel_bounds,
+                    extra_pixel_bounds,
+                )
+        print(self._extra_pixel_bounds)
 
     def render_cairo(self, width: int, height: int) -> typing.Any:
         """Render area using cairo
@@ -213,7 +233,7 @@ class Context:
         :return: extra pixel object bounds
         :rtype: PixelBoundsT
         """
-        max_l, max_t, max_r, max_b = 0, 0, 0, 0
+        max_l, max_t, max_r, max_b = self._extra_pixel_bounds
         attribution = self._tile_provider.attribution()
         if (attribution is None) or (attribution == ""):
             max_b = 12
@@ -223,7 +243,7 @@ class Context:
             max_t = max(max_t, t)
             max_r = max(max_r, r)
             max_b = max(max_b, b)
-        return (max_l, max_t, max_r, max_b)
+        return max_l, max_t, max_r, max_b
 
     def determine_center_zoom(
         self, width: int, height: int


### PR DESCRIPTION
This PR adds the possibility to not only add arbitrary bounds with the `add_bounds()` method, but also `extra_pixel_bounds`.
The idea of the PR is to add py-staticmaps as background image to `GpxTrackPoster` heatmaps.
The heatmaps are generated with three lines with different thicknesses and transparencies.
In edge cases it is possible that the static map doesn't cover the **thickness** of the heatmap line.