### PR TITLE
Feature/new tile providers

### DIFF
--- a/examples/draw_gpx.py
+++ b/examples/draw_gpx.py
@@ -11,7 +11,7 @@ import staticmaps
 context = staticmaps.Context()
 context.set_tile_provider(staticmaps.tile_provider_ArcGISWorldImagery)
 
-with open(sys.argv[1], "r", encoding='utf-8') as file:
+with open(sys.argv[1], "r", encoding="utf-8") as file:
     gpx = gpxpy.parse(file)
 
 for track in gpx.tracks:

--- a/examples/draw_gpx.py
+++ b/examples/draw_gpx.py
@@ -11,7 +11,7 @@ import staticmaps
 context = staticmaps.Context()
 context.set_tile_provider(staticmaps.tile_provider_ArcGISWorldImagery)
 
-with open(sys.argv[1], "r") as file:
+with open(sys.argv[1], "r", encoding='utf-8') as file:
     gpx = gpxpy.parse(file)
 
 for track in gpx.tracks:

--- a/staticmaps/cli.py
+++ b/staticmaps/cli.py
@@ -87,6 +87,13 @@ def main() -> None:
         default=staticmaps.tile_provider_OSM.name(),
     )
     args_parser.add_argument(
+        "--tiles-api-key",
+        dest="tiles_api_key",
+        metavar="API_KEY",
+        type=str,
+        default=None,
+    )
+    args_parser.add_argument(
         "--file-format",
         metavar="FORMAT",
         type=FileFormat,
@@ -104,7 +111,7 @@ def main() -> None:
 
     context = staticmaps.Context()
 
-    context.set_tile_provider(staticmaps.default_tile_providers[args.tiles])
+    context.set_tile_provider(staticmaps.default_tile_providers[args.tiles], args.tiles_api_key)
 
     if args.center is not None:
         context.set_center(staticmaps.parse_latlng(args.center))

--- a/staticmaps/context.py
+++ b/staticmaps/context.py
@@ -77,13 +77,17 @@ class Context:
         """
         self._tile_downloader = downloader
 
-    def set_tile_provider(self, provider: TileProvider) -> None:
+    def set_tile_provider(self, provider: TileProvider, api_key: typing.Optional[str] = None) -> None:
         """Set tile provider
 
         :param provider: tile provider
         :type provider: TileProvider
+        :param api_key: api key (if needed)
+        :type api_key: str
         """
         self._tile_provider = provider
+        if api_key:
+            self._tile_provider.set_api_key(api_key)
 
     def add_object(self, obj: Object) -> None:
         """Add object for the static map (e.g. line, area, marker)

--- a/staticmaps/tile_provider.py
+++ b/staticmaps/tile_provider.py
@@ -127,9 +127,25 @@ tile_provider_ArcGISWorldImagery = TileProvider(
     max_zoom=24,
 )
 
+tile_provider_Carto = TileProvider(
+    "carto",
+    url_pattern="http://$s.basemaps.cartocdn.com/rastertiles/light_all/$z/$x/$y.png",
+    shards=["a", "b", "c", "d"],
+    attribution="Maps (C) CARTO (C) OpenStreetMap.org contributors",
+    max_zoom=20,
+)
+
 tile_provider_CartoNoLabels = TileProvider(
     "carto-nolabels",
     url_pattern="http://$s.basemaps.cartocdn.com/rastertiles/light_nolabels/$z/$x/$y.png",
+    shards=["a", "b", "c", "d"],
+    attribution="Maps (C) CARTO (C) OpenStreetMap.org contributors",
+    max_zoom=20,
+)
+
+tile_provider_CartoDark = TileProvider(
+    "carto-dark",
+    url_pattern="http://$s.basemaps.cartocdn.com/rastertiles/dark_all/$z/$x/$y.png",
     shards=["a", "b", "c", "d"],
     attribution="Maps (C) CARTO (C) OpenStreetMap.org contributors",
     max_zoom=20,
@@ -156,7 +172,9 @@ default_tile_providers = {
     tile_provider_StamenToner.name(): tile_provider_StamenToner,
     tile_provider_StamenTonerLite.name(): tile_provider_StamenTonerLite,
     tile_provider_ArcGISWorldImagery.name(): tile_provider_ArcGISWorldImagery,
+    tile_provider_Carto.name(): tile_provider_Carto,
     tile_provider_CartoNoLabels.name(): tile_provider_CartoNoLabels,
+    tile_provider_CartoDark.name(): tile_provider_CartoDark,
     tile_provider_CartoDarkNoLabels.name(): tile_provider_CartoDarkNoLabels,
     tile_provider_None.name(): tile_provider_None,
 }

--- a/staticmaps/tile_provider.py
+++ b/staticmaps/tile_provider.py
@@ -159,6 +159,24 @@ tile_provider_CartoDarkNoLabels = TileProvider(
     max_zoom=20,
 )
 
+tile_provider_StadiaAlidadeSmooth = TileProvider(
+    "stadia-alidade-smooth",
+    url_pattern="https://tiles.stadiamaps.com/tiles/alidade_smooth/$z/$x/$y.png?api_key=$k",
+    shards=["a", "b", "c", "d"],
+    attribution="Maps (C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap.org contributors",
+    max_zoom=20,
+    api_key="",
+)
+
+tile_provider_StadiaAlidadeSmoothDark = TileProvider(
+    "stadia-alidade-smooth",
+    url_pattern="https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/$z/$x/$y.png?api_key=$k",
+    shards=["a", "b", "c", "d"],
+    attribution="Maps (C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap.org contributors",
+    max_zoom=20,
+    api_key="",
+)
+
 tile_provider_None = TileProvider(
     "none",
     url_pattern="",
@@ -176,5 +194,7 @@ default_tile_providers = {
     tile_provider_CartoNoLabels.name(): tile_provider_CartoNoLabels,
     tile_provider_CartoDark.name(): tile_provider_CartoDark,
     tile_provider_CartoDarkNoLabels.name(): tile_provider_CartoDarkNoLabels,
+    tile_provider_StadiaAlidadeSmooth.name(): tile_provider_StadiaAlidadeSmooth,
+    tile_provider_StadiaAlidadeSmoothDark.name(): tile_provider_StadiaAlidadeSmoothDark,
     tile_provider_None.name(): tile_provider_None,
 }

--- a/staticmaps/tile_provider.py
+++ b/staticmaps/tile_provider.py
@@ -174,7 +174,22 @@ tile_provider_StadiaAlidadeSmoothDark = TileProvider(
     shards=["a", "b", "c", "d"],
     attribution="Maps (C) Stadia Maps (C) OpenMapTiles (C) OpenStreetMap.org contributors",
     max_zoom=20,
-    api_key="",
+)
+
+tile_provider_JawgLight = TileProvider(
+    "jawg-light",
+    url_pattern="https://$s.tile.jawg.io/jawg-light/$z/$x/$y.png?access-token=$k",
+    shards=["a", "b", "c", "d"],
+    attribution="Maps (C) Jawg Maps (C) OpenStreetMap.org contributors",
+    max_zoom=22,
+)
+
+tile_provider_JawgDark = TileProvider(
+    "jawg-dark",
+    url_pattern="https://$s.tile.jawg.io/jawg-dark/$z/$x/$y.png?access-token=$k",
+    shards=["a", "b", "c", "d"],
+    attribution="Maps (C) Jawg Maps (C) OpenStreetMap.org contributors",
+    max_zoom=22,
 )
 
 tile_provider_None = TileProvider(
@@ -196,5 +211,7 @@ default_tile_providers = {
     tile_provider_CartoDarkNoLabels.name(): tile_provider_CartoDarkNoLabels,
     tile_provider_StadiaAlidadeSmooth.name(): tile_provider_StadiaAlidadeSmooth,
     tile_provider_StadiaAlidadeSmoothDark.name(): tile_provider_StadiaAlidadeSmoothDark,
+    tile_provider_JawgLight.name(): tile_provider_JawgLight,
+    tile_provider_JawgDark.name(): tile_provider_JawgDark,
     tile_provider_None.name(): tile_provider_None,
 }


### PR DESCRIPTION
This PR adds the ability to use map tile providers with api key an command line and adds [jawg](https://www.jawg.io/lab) and [stadiamaps](https://stadiamaps.com).