### PR TITLE
Fix attribution text width (and font size) calculation [Cairo]

### DIFF
--- a/staticmaps/cairo_renderer.py
+++ b/staticmaps/cairo_renderer.py
@@ -150,7 +150,7 @@ class CairoRenderer(Renderer):
         while True:
             self._context.set_font_size(font_size)
             _, f_descent, f_height, _, _ = self._context.font_extents()
-            t_width = self._context.text_extents(attribution)[3]
+            t_width = self._context.text_extents(attribution).width
             if t_width < width - 4:
                 break
             font_size = font_size - 0.25


### PR DESCRIPTION
`text_extents(attribution)[3]` refers to line height, not line width, e.g. `cairo.TextExtents(x_bearing=0.0, y_bearing=-18.0, width=252.0, height=27.0, x_advance=252.0, y_advance=0.0)`

changed `[3]` to `.width`, though `[2]` would do the same