### PR TITLE
Bugfix/pillow10:  Not compatible with Pillow=10.0.0 #31 

### DIFF
--- a/examples/draw_gpx.py
+++ b/examples/draw_gpx.py
@@ -11,7 +11,7 @@ import staticmaps
 context = staticmaps.Context()
 context.set_tile_provider(staticmaps.tile_provider_ArcGISWorldImagery)
 
-with open(sys.argv[1], "r", encoding='utf-8') as file:
+with open(sys.argv[1], "r", encoding="utf-8") as file:
     gpx = gpxpy.parse(file)
 
 for track in gpx.tracks:

--- a/examples/draw_gpx.py
+++ b/examples/draw_gpx.py
@@ -11,7 +11,7 @@ import staticmaps
 context = staticmaps.Context()
 context.set_tile_provider(staticmaps.tile_provider_ArcGISWorldImagery)
 
-with open(sys.argv[1], "r") as file:
+with open(sys.argv[1], "r", encoding='utf-8') as file:
     gpx = gpxpy.parse(file)
 
 for track in gpx.tracks:

--- a/staticmaps/pillow_renderer.py
+++ b/staticmaps/pillow_renderer.py
@@ -97,7 +97,7 @@ class PillowRenderer(Renderer):
         if (attribution is None) or (attribution == ""):
             return
         margin = 2
-        _, th = self.draw().textsize(attribution)
+        _, th = self.draw().textlength(attribution)
         w = self._trans.image_width()
         h = self._trans.image_height()
         overlay = PIL_Image.new("RGBA", self._image.size, (255, 255, 255, 0))

--- a/staticmaps/pillow_renderer.py
+++ b/staticmaps/pillow_renderer.py
@@ -97,9 +97,10 @@ class PillowRenderer(Renderer):
         if (attribution is None) or (attribution == ""):
             return
         margin = 2
-        _, th = self.draw().textlength(attribution)
         w = self._trans.image_width()
         h = self._trans.image_height()
+        left, top, right, bottom = self.draw().textbbox((margin, h - margin), attribution)
+        th = bottom - top
         overlay = PIL_Image.new("RGBA", self._image.size, (255, 255, 255, 0))
         draw = PIL_ImageDraw.Draw(overlay)
         draw.rectangle([(0, h - th - 2 * margin), (w, h)], fill=(255, 255, 255, 204))


### PR DESCRIPTION
This change request removes the use of ImageDraw.textsize() which was deprecated and has been removed in Pillow 10.0.
It solves #31 , but will **not** pass the CI/CD build as it still has python 3.6 in the workflow which was removed from Ubuntu and maybe even more issues.